### PR TITLE
Fix error thrown by pip3 in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ endif
 # mistune for markdown completion (optional)
 # psutil (optional)
 # setproctitle (optional)
-pip3 --user install neovim jedi mistune psutil setproctitle
+pip3 install --user neovim jedi mistune psutil setproctitle
 ```
 
 (Optional) It's easier to use

--- a/doc/nvim-completion-manager.txt
+++ b/doc/nvim-completion-manager.txt
@@ -46,7 +46,7 @@ Install the required pip modules for your python3:
 	# jedi library for python completion
 	# mistune for language specific completion on markdown
 	# psutil and setproctitle are optional utilities
-	pip3 --user install neovim jedi mistune psutil setproctitle
+	pip3 install --user neovim jedi mistune psutil setproctitle
 
 Note: If you're using vim8, you also need to install the `neovim` pip module
 for the python, depending which on of `has("python")` has `has("python3")` you


### PR DESCRIPTION
Command `pip3 --user install neovim` thrown the following error: "no such option: --user".