### PR TITLE
Better python detect

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,8 @@ completion in html style/script tag.
 
 ## Requirements
 
-- Neovim.
-- Or vim8 with `has("python")` or `has("python3")`
-- `python3` found in your `$PATH` env variable or setting
-  `g:python3_host_prog` to the full path of your python3 executable.
+- `has("python3")`.
+- If you're on vim8, [vim-hug-neovim-rpc](https://github.com/roxma/vim-hug-neovim-rpc).
 
 ## Installation
 

--- a/autoload/cm.vim
+++ b/autoload/cm.vim
@@ -87,8 +87,7 @@ func! cm#enable_for_buffer(...)
 		autocmd TextChangedI <buffer> call s:check_changes()
 	augroup END
 
-	call s:start_core_channel()
-	call s:notify_core_channel('cm_start_channels',g:_cm_sources,cm#context())
+    call s:start_core_channel()
 
 endfunc
 
@@ -404,18 +403,28 @@ function! s:on_core_channel_error(job_id, data, event)
 	echoe join(a:data,"\n")
 endfunction
 
-func! s:start_core_channel()
+func! s:start_core_channel(...)
 	if s:channel_started
 		return
 	endif
-	let l:py3 = get(g:,'python3_host_prog','python3')
-	let s:channel_jobid = call(s:jobstart,[[l:py3,g:_cm_start_py_path,'core',g:_cm_servername],{
+	let s:channel_started = 1
+
+	let g:_cm_py3 = get(g:,'python3_host_prog','')
+    if g:_cm_py3 == '' && has('python3')
+        " heavy weight
+        " but better support for python detection
+        python3 import sys
+        let g:_cm_py3 = py3eval('sys.executable')
+    endif
+    if g:_cm_py3 == ''
+        let g:_cm_py3 = 'python3'
+    endif
+
+	let s:channel_jobid = call(s:jobstart,[[g:_cm_py3, g:_cm_start_py_path, 'core', g:_cm_servername], {
 			\ 'on_exit' : function('s:on_core_channel_exit'),
 			\ 'on_stderr' : function('s:on_core_channel_error'),
 			\ 'detach'  : 1,
 			\ }])
-
-	let s:channel_started = 1
 endfunc
 
 fun s:on_core_channel_exit(job_id, data, event)

--- a/autoload/cm.vim
+++ b/autoload/cm.vim
@@ -547,7 +547,7 @@ func! s:on_changed()
 	call s:notify_core_channel('cm_refresh',g:_cm_sources,cm#context(),0)
 endfunc
 
-func! cm#_auto_enable_check()
+func! cm#_auto_enable_check(...)
 	if exists('b:cm_enable') && b:cm_enable!=2
 		return
 	endif

--- a/plugin/cm.vim
+++ b/plugin/cm.vim
@@ -15,16 +15,25 @@ if !exists('g:cm_multi_threading')
 	endif
 endif
 
+func! s:smart_enable(...)
+    au BufWinEnter * call cm#_auto_enable_check()
+    " Unite's `buftype` is not set when BufWinEnter is triggered, use this as
+    " workaround
+    au OptionSet buftype call cm#_auto_enable_check()
+endfunc
+
+func! s:smart_enable_timer(...)
+    call cm#_auto_enable_check()
+endfunc
+
+let g:cm_startup_delay = get(g:, 'cm_startup_delay', 500)
+
 if get(g:,'cm_smart_enable',1)
-
-	au BufWinEnter * call cm#_auto_enable_check()
-	" Unite's `buftype` is not set when BufWinEnter is triggered, use this as
-	" workaround
-	au OptionSet buftype call cm#_auto_enable_check()
-
-	" disable clang default mapping by default,
-	" https://github.com/Rip-Rip/clang_complete/pull/515
-	let g:clang_make_default_keymappings = get(g:,'clang_make_default_keymappings',0)
+    if g:cm_startup_delay
+        call timer_start(g:cm_startup_delay, function('s:smart_enable_timer'))
+    else
+        call s:smart_enable()
+    endif
 endif
 
 let g:cm_matcher = get(g:,'cm_matcher',{'module': 'cm_matchers.prefix_matcher', 'case': 'smartcase'})
@@ -62,7 +71,7 @@ let g:cm_refresh_default_min_word_len = get(g:,'cm_refresh_default_min_word_len'
 
 let g:cm_completeopt=get(g:,'cm_completeopt','menu,menuone,noinsert,noselect')
 
-func! s:lazy_init()
+func! s:snippet_init()
 	if !exists('g:cm_completed_snippet_enable')
 		if get(g:,'neosnippet#enable_completed_snippet',0)
 			let g:cm_completed_snippet_enable = 1
@@ -80,7 +89,7 @@ func! s:lazy_init()
 	endif
 endfunc
 
-au User CmSetup call s:lazy_init()
+au User CmSetup call s:snippet_init()
 
 " use did_plugin_ultisnips to detect the installation of ultisnips
 " https://github.com/SirVer/ultisnips/blob/76ebfec3cf7340a1edd90ea052b16910733c96b0/autoload/UltiSnips.vim#L1
@@ -116,17 +125,4 @@ au User CmSetup call cm#register_source({'name' : 'cm-css',
 		\ 'cm_refresh': {'omnifunc': 'csscomplete#CompleteCSS'},
 		\ })
 
-
-" " keyword
-" call cm#register_source({
-" 		\ 'name' : 'cm-bufkeyword',
-" 		\ 'priority': 5, 
-" 		\ 'abbreviation': 'Key',
-" 		\ 'channel': {
-" 		\		'type': 'python3',
-" 		\		'path': 'autoload/cm/sources/cm_bufkeyword.py',
-" 		\		'events':['CursorHold','CursorHoldI','BufEnter','BufWritePost','TextChangedI'],
-" 		\		'detach':1,
-" 		\ },
-" 		\ })
 

--- a/plugin/cm.vim
+++ b/plugin/cm.vim
@@ -15,27 +15,6 @@ if !exists('g:cm_multi_threading')
 	endif
 endif
 
-func! s:smart_enable(...)
-    au BufWinEnter * call cm#_auto_enable_check()
-    " Unite's `buftype` is not set when BufWinEnter is triggered, use this as
-    " workaround
-    au OptionSet buftype call cm#_auto_enable_check()
-endfunc
-
-func! s:smart_enable_timer(...)
-    call cm#_auto_enable_check()
-endfunc
-
-let g:cm_startup_delay = get(g:, 'cm_startup_delay', 500)
-
-if get(g:,'cm_smart_enable',1)
-    if g:cm_startup_delay
-        call timer_start(g:cm_startup_delay, function('s:smart_enable_timer'))
-    else
-        call s:smart_enable()
-    endif
-endif
-
 let g:cm_matcher = get(g:,'cm_matcher',{'module': 'cm_matchers.prefix_matcher', 'case': 'smartcase'})
 
 if !exists('g:cm_completekeys')
@@ -71,6 +50,7 @@ let g:cm_refresh_default_min_word_len = get(g:,'cm_refresh_default_min_word_len'
 
 let g:cm_completeopt=get(g:,'cm_completeopt','menu,menuone,noinsert,noselect')
 
+" runs after snippet plugin is loaded
 func! s:snippet_init()
 	if !exists('g:cm_completed_snippet_enable')
 		if get(g:,'neosnippet#enable_completed_snippet',0)
@@ -125,4 +105,15 @@ au User CmSetup call cm#register_source({'name' : 'cm-css',
 		\ 'cm_refresh': {'omnifunc': 'csscomplete#CompleteCSS'},
 		\ })
 
+func! s:startup(...)
+    if get(g:,'cm_smart_enable',1)
+        call cm#_auto_enable_check()
+        augroup cm_smart_enable
+            au!
+            au BufEnter * call cm#_auto_enable_check()
+            au OptionSet buftype call cm#_auto_enable_check()
+        augroup end
+    endif
+endfunc
 
+call timer_start(get(g:, 'cm_startup_delay', 100), function('s:startup'))

--- a/pythonx/cm_core.py
+++ b/pythonx/cm_core.py
@@ -53,8 +53,8 @@ class CoreHandler(cm.Base):
         # load configurations
         self._servername = self.nvim.vars['_cm_servername']
         self._start_py   = self.nvim.vars['_cm_start_py_path']
-        self._py3        = self.nvim.eval("get(g:,'python3_host_prog','python3')")
-        self._py2        = self.nvim.eval("get(g:,'python_host_prog','python2')")
+        self._py3        = self.nvim.vars['_cm_py3']
+        self._py2        = self.nvim.vars("get(g:,'python_host_prog','python2')")
         self._complete_delay = self.nvim.vars['cm_complete_delay']
         self._completed_snippet_enable = self.nvim.vars['cm_completed_snippet_enable']
         self._completed_snippet_engine = self.nvim.vars['cm_completed_snippet_engine']

--- a/pythonx/cm_core.py
+++ b/pythonx/cm_core.py
@@ -54,7 +54,7 @@ class CoreHandler(cm.Base):
         self._servername = self.nvim.vars['_cm_servername']
         self._start_py   = self.nvim.vars['_cm_start_py_path']
         self._py3        = self.nvim.vars['_cm_py3']
-        self._py2        = self.nvim.vars("get(g:,'python_host_prog','python2')")
+        self._py2        = self.nvim.eval("get(g:,'python_host_prog','python2')")
         self._complete_delay = self.nvim.vars['cm_complete_delay']
         self._completed_snippet_enable = self.nvim.vars['cm_completed_snippet_enable']
         self._completed_snippet_engine = self.nvim.vars['cm_completed_snippet_engine']


### PR DESCRIPTION
This PR slightly simplifies the requirements on neovim. `python3` in `$PATH` is no longer required. It only requires `has("python3")`

Due to the heavy weight loading of `:python3` command, this PR also adds delay init feature, to improve the startuptime.

**I'll merge this PR after I test it on Windows.**