### PR TITLE
Added way to inspect source proc stdout/stderr

### DIFF
--- a/pythonx/cm_core.py
+++ b/pythonx/cm_core.py
@@ -675,11 +675,7 @@ class CoreHandler(cm.Base):
         # has not been started yet, start it now
         logger.info('starting channels for %s: %s',name, cmd)
 
-        debug_env_var = 'NVIM_NCM_SHARE_SOURCE_PROC_OUTPUT'
-        if debug_env_var in os.environ and int(os.environ[debug_env_var]) > 0:
-            proc = subprocess.Popen(cmd,stdin=subprocess.DEVNULL,stdout=sys.stdout,stderr=sys.stderr)
-        else:
-            proc = subprocess.Popen(cmd,stdin=subprocess.DEVNULL,stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL)
+        proc = subprocess.Popen(cmd,stdin=subprocess.DEVNULL,stdout=sys.stdout,stderr=sys.stderr)
         process_info['pid'] = proc.pid
         process_info['proc'] = proc
 

--- a/pythonx/cm_core.py
+++ b/pythonx/cm_core.py
@@ -675,7 +675,11 @@ class CoreHandler(cm.Base):
         # has not been started yet, start it now
         logger.info('starting channels for %s: %s',name, cmd)
 
-        proc = subprocess.Popen(cmd,stdin=subprocess.DEVNULL,stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL)
+        debug_env_var = 'NVIM_NCM_SHARE_SOURCE_PROC_OUTPUT'
+        if debug_env_var in os.environ and int(os.environ[debug_env_var]) > 0:
+            proc = subprocess.Popen(cmd,stdin=subprocess.DEVNULL,stdout=sys.stdout,stderr=sys.stderr)
+        else:
+            proc = subprocess.Popen(cmd,stdin=subprocess.DEVNULL,stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL)
         process_info['pid'] = proc.pid
         process_info['proc'] = proc
 


### PR DESCRIPTION
This is a result of my effort detailed in https://github.com/roxma/clang_complete/pull/6

I found it useful to get the `stdout` and `stderr` from the source processes to debug why a source process might be dead. I figure being able to enable/disable that without a source change would be a convenient addition to [the trouble shooting wiki](https://github.com/roxma/nvim-completion-manager/wiki/Trouble-shooting).

Feel free to bike shed names and whatnot.