### PR TITLE
Optimize for cm_refresh, allow triggering in the middle of a word

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ let g:cm_sources_override = {
   [autoload/cm/sources/ultisnips.vim](autoload/cm/sources/ultisnips.vim)
 - For really async completion source (strongly encoraged), refer to the rust
   completion: [nvim-cm-racer](https://github.com/roxma/nvim-cm-racer)
+- `:help ncm-source-examples` for minimal examples
 
 Please upload your screenshot
 [here](https://github.com/roxma/nvim-completion-manager/issues/12) after you

--- a/autoload/cm.vim
+++ b/autoload/cm.vim
@@ -172,19 +172,24 @@ func! cm#register_source(info)
 
 	let a:info['enable'] = get(a:info,'enable',g:cm_sources_enable)
 
-	" calculating cm_refresh_min_word_len
-	if !has_key(a:info,'cm_refresh_min_word_len')
-		if type(g:cm_refresh_default_min_word_len)==type(1)
-			let a:info['cm_refresh_min_word_len'] = g:cm_refresh_default_min_word_len
+    " the name cm_refresh_min_word_len is deprecated, it will be removed
+    " in the future
+    if has_key(a:info, 'cm_refresh_min_word_len')
+        let a:info['cm_refresh_length'] = a:info['cm_refresh_min_word_len']
+    endif
+
+	if !has_key(a:info,'cm_refresh_length')
+		if type(g:cm_refresh_length)==type(1)
+			let a:info['cm_refresh_length'] = g:cm_refresh_length
 		else
 			" format: [ [ minimal priority, min length ], []]
 			"
 			" Configure by min priority level. Use the max priority setting
 			" available
 			let l:max = -1
-			for l:e in g:cm_refresh_default_min_word_len
+			for l:e in g:cm_refresh_length
 				if (a:info['priority'] >= l:e[0]) && (l:e[0] > l:max)
-					let a:info['cm_refresh_min_word_len'] = l:e[1]
+					let a:info['cm_refresh_length'] = l:e[1]
 					let l:max = l:e[0]
 				endif
 			endfor

--- a/doc/nvim-completion-manager.txt
+++ b/doc/nvim-completion-manager.txt
@@ -267,9 +267,9 @@ g:cm_auto_popup
 			trigger the popup menu.
 			Default: 1
 
-						*g:cm_refresh_default_min_word_len*
-g:cm_refresh_default_min_word_len
-			The default value for |cm_refresh_min_word_len|.
+						*g:cm_refresh_length*
+g:cm_refresh_length
+			The default value for |cm_refresh_length|.
 
 			Default: `[[1,4],[7,3]]`
 			Format: a |List| as [[ min priority, min len ],...],
@@ -353,7 +353,7 @@ cm#register_source({source})
 						*cm_refresh_patterns*
 	cm_refresh_patterns			*NCM-cm_refresh_patterns*
 			An extra |List| of PCRE patterns (python regex),
-			besides |cm_refresh_min_word_len|, for auto triggering
+			besides |cm_refresh_length|, for auto triggering
 			popup menu. 
 
 						*cm_refresh*
@@ -371,22 +371,26 @@ cm#register_source({source})
 
 				`{'omnifunc': 'csscomplete#CompleteCSS'}`
 
-						*NCM-cm_refresh_min_word_len*
-	cm_refresh_min_word_len			*cm_refresh_min_word_len*
+						*NCM-cm_refresh_length*
+	cm_refresh_length			*cm_refresh_length*
 			The minimum length of the matching word for auto
 			triggering popup menu.
 
-			If len(matching word) >= cm_refresh_min_word_len, a
-			|cm_refresh-notification| will be triggered for this
-			source.
+			If it contains a negative value,
+			|cm_refresh-notification| will only get triggered by
+			|cm_refresh_patterns|.
 
-			Default: |g:cm_refresh_default_min_word_len|
+			Otherwise, if len(matching word) >= cm_refresh_length,
+			a |cm_refresh-notification| will be triggered for the
+			source. 
+
+			Default: |g:cm_refresh_length|
 
 	early_cache				*NCM-early_cache*
 			Cache the completion candidates whenever a word
 			pattern matches, the result will not be popped up
 			until the word gets long enough
-			(|cm_refresh_min_word_len|) or matches
+			(|cm_refresh_length|) or matches
 			|cm_refresh_patterns|. It feels faster when candidates
 			are already cached before the popup menu is displayed.
 

--- a/plugin/cm.vim
+++ b/plugin/cm.vim
@@ -58,7 +58,9 @@ let g:cm_sources_enable = get(g:,'cm_sources_enable',1)
 let g:cm_sources_override = get(g:,'cm_sources_override',{})
 
 " format: [ (minimal priority, min length), ()]
-let g:cm_refresh_default_min_word_len = get(g:,'cm_refresh_default_min_word_len',[[1,4],[7,3]])
+" the name cm_refresh_default_min_word_len is deprecated, it will be removed
+" in the future
+let g:cm_refresh_length = get(g:, 'cm_refresh_length', get(g:, 'cm_refresh_default_min_word_len', [[1, 4], [7, 3]]))
 
 let g:cm_completeopt=get(g:,'cm_completeopt','menu,menuone,noinsert,noselect')
 

--- a/pythonx/cm_core.py
+++ b/pythonx/cm_core.py
@@ -325,8 +325,13 @@ class CoreHandler(cm.Base):
                         if name in self._matches:
                             self._matches[name]['enable'] = True
 
-                    if (name in self._matches) and not self._matches[name]['refresh'] and not force and self._matches[name]['startcol']==ctx['startcol']:
-                        logger.debug('cached <%s>, ignore cm_refresh', name)
+                    if (
+                            (name in self._matches) and 
+                            not self._matches[name]['refresh'] and 
+                            not force and 
+                            self._matches[name]['startcol']==ctx['startcol']
+                        ):
+                        logger.debug('<%s> has been cached, <%s> candidates', name, len(self._matches[name]['matches']))
                         continue
 
                     if 'cm_refresh' in info:
@@ -412,7 +417,7 @@ class CoreHandler(cm.Base):
             last_word_removed = typed
             word_len          = 0
 
-        minimum_length = info['cm_refresh_min_word_len']
+        minimum_length = info['cm_refresh_length']
 
         # always match
         if minimum_length==0:
@@ -421,7 +426,7 @@ class CoreHandler(cm.Base):
         if force and word_len>0:
             return True
 
-        if word_len >= minimum_length:
+        if minimum_length > 0 and word_len >= minimum_length:
             return True
 
         # check source extra patterns

--- a/pythonx/cm_core.py
+++ b/pythonx/cm_core.py
@@ -317,10 +317,12 @@ class CoreHandler(cm.Base):
                             logger.debug('<%s> early_caching', name)
                         else:
                             logger.debug('cm_refresh ignore <%s>, force[%s] early_cache[%s]', name, force, info['early_cache'])
+                            if name in self._matches:
+                                self._matches[name]['enable'] = False
                             continue
                     else:
+                        # enable cached
                         if name in self._matches:
-                            # enable previous early_cache, if available
                             self._matches[name]['enable'] = True
 
                     if (name in self._matches) and not self._matches[name]['refresh'] and not force and self._matches[name]['startcol']==ctx['startcol']:

--- a/pythonx/cm_core.py
+++ b/pythonx/cm_core.py
@@ -330,7 +330,7 @@ class CoreHandler(cm.Base):
                             not self._matches[name]['refresh'] and 
                             not force and 
                             self._matches[name]['startcol']==ctx['startcol'] and
-                            ctx.get('group', '') == self._matches[name]['ctx'].get('group', '')
+                            ctx.get('group', '') == self._matches[name]['context'].get('group', '')
                         ):
                         logger.debug('<%s> has been cached, <%s> candidates', name, len(self._matches[name]['matches']))
                         continue
@@ -437,11 +437,11 @@ class CoreHandler(cm.Base):
                 # `$` is not necessary to be specified in cm_refresh_patterns
                 # anymore
                 pattern = pattern.rstrip('$')
-                pattern += '(' + word_pattern + ')?$'
+                pattern += '(?P<word>(' + word_pattern + ')?)$'
 
                 matched = re.search(pattern, typed)
                 if matched:
-                    ctx['group'] = typed[ : matched.start(len(matched.groups())-1)]
+                    ctx['group'] = typed[ : matched.start('word')]
                     return True
 
         min_len = info['cm_refresh_length']

--- a/pythonx/cm_sources/cm_filepath.py
+++ b/pythonx/cm_sources/cm_filepath.py
@@ -13,7 +13,7 @@ register_source(name='cm-filepath',
                 abbreviation='path',
                 word_pattern=r'''([^\W]|[-.~%$])+''',
                 cm_refresh_patterns=[
-                    r'''(\.[/\\]|[a-zA-Z]:\\|~\/)([^\W]|[-.~%$]|[/\\])*$''', r'''[/\\$]([^\W]|[-.~%$]|[/\\])+[/\\]$'''],
+                    r'''(\.[/\\]+|[a-zA-Z]:\\+|~\/+)''', r'''([^\W]|[-.~%$]|[/\\])+[/\\]+'''],
                 options=dict(path_pattern=r'''(([^\W]|[-.~%$]|[/\\])+)'''),
                 sort=0,
                 priority=6,)

--- a/pythonx/cm_sources/cm_gocode.py
+++ b/pythonx/cm_sources/cm_gocode.py
@@ -17,7 +17,7 @@ register_source(name='cm-gocode',
                 early_cache=1,
                 scoping=True,
                 scopes=['go'],
-                cm_refresh_patterns=[r'\.(\w*)$'],)
+                cm_refresh_patterns=[r'\.'],)
 
 import re
 import subprocess

--- a/pythonx/cm_sources/cm_jedi.py
+++ b/pythonx/cm_sources/cm_jedi.py
@@ -11,8 +11,8 @@ register_source(name='cm-jedi',
                 scopes=['python'],
                 multi_thread=0,
                 early_cache=1,
-                # The last two patterns is for displaying function signatures [r'\(\s?(\w*)$',r',(\s?\w*)$']
-                cm_refresh_patterns=[r'^(import|from).*?\s(\w*)$',r'\.\w*$',r'\(\s?(\w*)$',r',\s?(\w*)$'],)
+                # The last two patterns is for displaying function signatures r'\(\s?', r',\s?'
+                cm_refresh_patterns=[r'^(import|from).*?\s', r'\.', r'\(\s?', r',\s?'],)
 
 import re
 import jedi

--- a/pythonx/cm_sources/cm_keyword_continue.py
+++ b/pythonx/cm_sources/cm_keyword_continue.py
@@ -18,7 +18,7 @@ register_source(name='cm-keyword-continue',
                 priority=5,
                 abbreviation='',
                 word_pattern=r'\w+',
-                cm_refresh_min_word_len=0,
+                cm_refresh_length=0,
                 auto_popup=0,
                 sort=0,)
 


### PR DESCRIPTION
This PR should support #60  better. It allows triggering refresh in the middle of a word. It should be more flexible than previous implementation.


@SevereOverfl0w , Would you test this PR with https://github.com/clojure-vim/async-clj-omni, removing the `refresh=True`, with `cm_refresh_patterns=[r'/$']`?
