### PR TITLE
Fix tmux source

### DIFF
--- a/pythonx/cm_sources/cm_tmux.py
+++ b/pythonx/cm_sources/cm_tmux.py
@@ -17,7 +17,7 @@ import re
 import logging
 import subprocess
 
-logger = logging.getLogger(__name__).
+logger = getLogger(__name__)
 
 class Source(Base):
 

--- a/pythonx/cm_sources/cm_tmux.py
+++ b/pythonx/cm_sources/cm_tmux.py
@@ -62,7 +62,6 @@ class Source(Base):
             outs, errs = proc.communicate(timeout=15)
             pane_ids = outs.decode('utf-8')
 
-
             for pane_id in pane_ids.strip().split('\n'):
                 proc = subprocess.Popen(args=['tmux', 'capture-pane', '-p', '-t', '{}.{}'.format(win_index,pane_id)],
                                         stdin=subprocess.PIPE,


### PR DESCRIPTION
Before this commit, tmux source assumed panes started at index 0.
That can, however, be changed with:

```
setw -g pane-base-index 1
```

Because of this, I changed the implementation so that it checks for the
actual indices of each window rather than assuming it starts at zero.