### PR TITLE
Add option g:cm_complete_start_delay, for fast-typing performance.

### DIFF
--- a/autoload/cm.vim
+++ b/autoload/cm.vim
@@ -270,6 +270,7 @@ let g:_cm_channel_id = -1
 let s:channel_started = 0
 let g:_cm_start_py_path = globpath(&rtp,'pythonx/cm_start.py',1)
 let s:snippets = []
+let s:complete_begin_timer = 0
 
 " global lock for being compatible with other plugins:
 " 1 - vim-multiple-cursors
@@ -490,11 +491,26 @@ func! s:check_changes(...)
     endif
 
 	let l:tick = s:changetick()
+
 	if l:tick!=s:lasttick
 		let s:lasttick = l:tick
-		call s:on_changed()
+
+        if g:cm_complete_start_delay == 0
+            call s:on_changed()
+        else
+            if s:complete_begin_timer
+                call timer_stop(s:complete_begin_timer)
+            endif
+            let s:complete_begin_timer = timer_start(g:cm_complete_start_delay, function('s:on_changed'), {'repeat': 1})
+        endif
 	endif
+
 	call s:check_and_inject_snippet()
+endfunc
+
+func! s:complete_begin_timer_handler(...)
+    let s:complete_begin_timer = 0
+    call s:on_changed()
 endfunc
 
 func! s:check_and_inject_snippet()

--- a/doc/nvim-completion-manager.txt
+++ b/doc/nvim-completion-manager.txt
@@ -188,14 +188,20 @@ g:cm_sources_override
 			    \ }
 <			See |cm#register_source()| for more information.
 
-						*g:cm_complete_delay*
-g:cm_complete_delay		
+						*g:cm_complete_start_delay* 
+g:cm_complete_start_delay 
+			Wait for an interval before candidate calculation, to
+			improve editor performance for fast typing
+			Default: 50
+
+						*g:cm_complete_popup_delay*
+g:cm_complete_popup_delay		
 			Wait for an interval before popping up, in
 			milliseconds.  This would reduce the popup menu
 			flickering when multiple sources are updating the
 			popup menu in a short interval. Use an interval long
 			enough for computer and short enough for human.  
-			Default: 80
+			Default: 50
 
 						*g:cm_matcher*
 g:cm_matcher 

--- a/doc/nvim-completion-manager.txt
+++ b/doc/nvim-completion-manager.txt
@@ -192,16 +192,18 @@ g:cm_sources_override
 g:cm_complete_start_delay 
 			Wait for an interval, in milliseconds, before
 			candidate calculation, to improve editor performance
-			for fast typing.
+			for fast typing. This is useful when dealing with
+			slow, sync completion source.
 			Default: 0
 
 						*g:cm_complete_popup_delay*
 g:cm_complete_popup_delay		
-			Wait for an interval before popping up, in
-			milliseconds.  This would reduce the popup menu
-			flickering when multiple sources are updating the
-			popup menu in a short interval. Use an interval long
-			enough for computer and short enough for human.  
+			After candidate calculation has started, wait for an
+			interval, in milliseconds, before popping up.  This
+			would reduce the popup menu flickering when multiple
+			sources are updating the popup menu in a short
+			interval. Use an interval long enough for computer and
+			short enough for human.  
 			Default: 50
 
 						*g:cm_matcher*

--- a/doc/nvim-completion-manager.txt
+++ b/doc/nvim-completion-manager.txt
@@ -190,9 +190,10 @@ g:cm_sources_override
 
 						*g:cm_complete_start_delay* 
 g:cm_complete_start_delay 
-			Wait for an interval before candidate calculation, to
-			improve editor performance for fast typing
-			Default: 50
+			Wait for an interval, in milliseconds, before
+			candidate calculation, to improve editor performance
+			for fast typing.
+			Default: 0
 
 						*g:cm_complete_popup_delay*
 g:cm_complete_popup_delay		

--- a/plugin/cm.vim
+++ b/plugin/cm.vim
@@ -32,8 +32,8 @@ endif
 let g:cm_auto_popup = get(g:,'cm_auto_popup',1)
 
 " Wait for an interval before candidate calculation, to improve editor
-" performance for fast typing
-let g:cm_complete_start_delay = get(g:,'cm_complete_start_delay', 50)
+" performance for fast typing.
+let g:cm_complete_start_delay = get(g:,'cm_complete_start_delay', 0)
 
 " Wait for an interval before popping up, in milliseconds, this would reduce
 " the popup menu flickering when multiple sources are updating the popup menu

--- a/plugin/cm.vim
+++ b/plugin/cm.vim
@@ -31,11 +31,16 @@ endif
 
 let g:cm_auto_popup = get(g:,'cm_auto_popup',1)
 
+" Wait for an interval before candidate calculation, to improve editor
+" performance for fast typing
+let g:cm_complete_start_delay = get(g:,'cm_complete_start_delay', 50)
+
 " Wait for an interval before popping up, in milliseconds, this would reduce
 " the popup menu flickering when multiple sources are updating the popup menu
 " in a short interval, use an interval long enough for computer and short
 " enough for human
-let g:cm_complete_delay = get(g:,'cm_complete_delay',80)
+" The name cm_complete_delay is deprecated
+let g:cm_complete_popup_delay = get(g:, 'cm_complete_popup_delay', get(g:, 'cm_complete_delay', 50))
 
 " Automatically enable all registered sources by default. Set it to 0 if you
 " want to manually enable the registered sources you want by

--- a/pythonx/cm_core.py
+++ b/pythonx/cm_core.py
@@ -56,7 +56,7 @@ class CoreHandler(cm.Base):
         self._start_py   = self.nvim.vars['_cm_start_py_path']
         self._py3        = self.nvim.vars['_cm_py3']
         self._py2        = self.nvim.eval("get(g:,'python_host_prog','python2')")
-        self._complete_delay = self.nvim.vars['cm_complete_delay']
+        self._complete_delay = self.nvim.vars['cm_complete_popup_delay']
         self._completed_snippet_enable = self.nvim.vars['cm_completed_snippet_enable']
         self._completed_snippet_engine = self.nvim.vars['cm_completed_snippet_engine']
         self._multi_thread = int(self.nvim.vars['cm_multi_threading'])


### PR DESCRIPTION
This PR address #118

@felixjung 

Please test this PR

I've only tested it by holding the `<backspace>` key as in the gif you posted.

Tweak the value of `g:cm_complete_start_delay` if necessary.  Current default is 50ms. I could delete about 30 characters per second on my nvim, when holding the `<backspace>` key.