### PR TITLE
Add new completion source for words in other buffers

### DIFF
--- a/pythonx/cm_sources/cm_otherbufkeyword.py
+++ b/pythonx/cm_sources/cm_otherbufkeyword.py
@@ -21,6 +21,7 @@ class Source(Base):
 
         def __init__(self):
             self.changed = False
+            self.changedtick = None
             self.deleted = False
             self.words = set()
 
@@ -57,7 +58,8 @@ class Source(Base):
     def cm_event(self, event, ctx, *args):
         if event == 'BufLeave':
             buf = self._buffers[ctx['bufnr']]
-            buf.changed = True
+            if buf.changedtick != ctx['changedtick']:
+                buf.changed = True
         self.update()
 
     def cm_refresh(self, info, ctx):

--- a/pythonx/cm_sources/cm_otherbufkeyword.py
+++ b/pythonx/cm_sources/cm_otherbufkeyword.py
@@ -65,12 +65,12 @@ class Source(Base):
     def cm_refresh(self, info, ctx):
         def gen():
             for num, buf in self._buffers.items():
+                bufname = self.nvim.buffers[num].name
                 # current buffer is handled by different source
                 if num != ctx['bufnr']:
                     for word in buf.words:
-                        yield word
+                        yield dict(word=word, icase=1, info=bufname)
 
-        matches = (dict(word=word, icase=1) for word in gen())
-        matches = self.matcher.process(info, ctx, ctx['startcol'], matches)
+        matches = self.matcher.process(info, ctx, ctx['startcol'], gen())
 
         self.complete(info, ctx, ctx['startcol'], matches)

--- a/pythonx/cm_sources/cm_otherbufkeyword.py
+++ b/pythonx/cm_sources/cm_otherbufkeyword.py
@@ -16,6 +16,14 @@ logger = getLogger(__name__)
 
 class Source(Base):
 
+    class BufferData:
+        __sltos__ = ('changed', 'changedtick', 'deleted', 'words')
+
+        def __init__(self):
+            self.changed = False
+            self.deleted = False
+            self.words = set()
+
     def __init__(self, nvim):
         super(Source,self).__init__(nvim)
         self._compiled = re.compile(r'\w+')
@@ -24,31 +32,32 @@ class Source(Base):
 
     def update(self):
         for buf in self._buffers.values():
-            buf['deleted'] = True
+            buf.deleted = True
 
         for buf in self.nvim.buffers:
             schedule_update = (not buf.number in self._buffers) or \
-                (self._buffers[buf.number]['changed'])
+                (self._buffers[buf.number].changed)
             if schedule_update:
                 self._buffers[buf.number] = self.rescan_buffer(buf)
-            self._buffers[buf.number]['deleted'] = False
+            self._buffers[buf.number].deleted = False
 
-        self._buffers = { k:v for k, v in self._buffers.items() if not v['deleted'] }
+        self._buffers = { k:v for k, v in self._buffers.items() if not v.deleted }
 
     def rescan_buffer(self, buf):
-        result = { 'changed': False, 'words': set() }
+        result = self.BufferData()
         logger.info('rescan_buffer(%s)', buf.number)
 
         for line in buf:
             for word in self._compiled.finditer(line):
-                result['words'].add(word.group())
+                result.words.add(word.group())
 
-        logger.info('keyword refresh complete, count: %s', len(result['words']))
+        logger.info('keyword refresh complete, count: %s', len(result.words))
         return result
 
     def cm_event(self, event, ctx, *args):
         if event == 'BufLeave':
-            self._buffers[ctx['bufnr']]['changed'] = True
+            buf = self._buffers[ctx['bufnr']]
+            buf.changed = True
         self.update()
 
     def cm_refresh(self, info, ctx):
@@ -56,7 +65,7 @@ class Source(Base):
             for num, buf in self._buffers.items():
                 # current buffer is handled by different source
                 if num != ctx['bufnr']:
-                    for word in buf['words']:
+                    for word in buf.words:
                         yield word
 
         matches = (dict(word=word, icase=1) for word in gen())

--- a/pythonx/cm_sources/cm_otherbufkeyword.py
+++ b/pythonx/cm_sources/cm_otherbufkeyword.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Author: Stefan Haller <fgrsnau@gmail.com>
+
+from cm import register_source
+register_source(name='cm-otherbufkeyword',
+                priority=4,
+                abbreviation='Bufs',
+                events=['BufAdd', 'BufDelete', 'BufLeave'],)
+
+from cm import getLogger, Base
+import re
+import cm_default
+
+logger = getLogger(__name__)
+
+class Source(Base):
+
+    def __init__(self, nvim):
+        super(Source,self).__init__(nvim)
+        self._compiled = re.compile(r'\w+')
+        self._buffers = {}
+        self.update()
+
+    def update(self):
+        for buf in self._buffers.values():
+            buf['deleted'] = True
+
+        for buf in self.nvim.buffers:
+            schedule_update = (not buf.number in self._buffers) or \
+                (self._buffers[buf.number]['changed'])
+            if schedule_update:
+                self._buffers[buf.number] = self.rescan_buffer(buf)
+            self._buffers[buf.number]['deleted'] = False
+
+        self._buffers = { k:v for k, v in self._buffers.items() if not v['deleted'] }
+
+    def rescan_buffer(self, buf):
+        result = { 'changed': False, 'words': set() }
+        logger.info('rescan_buffer(%s)', buf.number)
+
+        for line in buf:
+            for word in self._compiled.finditer(line):
+                result['words'].add(word.group())
+
+        logger.info('keyword refresh complete, count: %s', len(result['words']))
+        return result
+
+    def cm_event(self, event, ctx, *args):
+        if event == 'BufLeave':
+            self._buffers[ctx['bufnr']]['changed'] = True
+        self.update()
+
+    def cm_refresh(self, info, ctx):
+        def gen():
+            for num, buf in self._buffers.items():
+                # current buffer is handled by different source
+                if num != ctx['bufnr']:
+                    for word in buf['words']:
+                        yield word
+
+        matches = (dict(word=word, icase=1) for word in gen())
+        matches = self.matcher.process(info, ctx, ctx['startcol'], matches)
+
+        self.complete(info, ctx, ctx['startcol'], matches)

--- a/pythonx/cm_sources/cm_otherbufkeyword.py
+++ b/pythonx/cm_sources/cm_otherbufkeyword.py
@@ -3,7 +3,7 @@
 # Author: Stefan Haller <fgrsnau@gmail.com>
 
 from cm import register_source
-register_source(name='cm-otherbufkeyword',
+register_source(name='cm-otherbuf',
                 priority=4,
                 abbreviation='Bufs',
                 events=['BufAdd', 'BufDelete', 'BufLeave'],)


### PR DESCRIPTION
Hi,

I was missing the functionality to complete a word which is present in any other open buffer. Hence I have implemented a new completion source. This is basically `cm_bufkeyword` for all buffers but the current one. I think a second completion source is good, as we can have a separate priority and the user is able to easily disable the whole thing. Additionally, I don’t use the same word-pattern as `cm_bufkeyword` but a very generic one (the scope might change when moving between buffers). Naming this beast is a little bit complicated though. I am definitely willing to change it to something less clunky.

Are you generally interested in such a new completion source? When I find the time I might add additional functionality like:

- [ ] Track changes and only set the updated-flag when a change has been performed. (Currently, the updated-flag is set on the BufLeave event.)
- [ ] Check the fileformat setting of the buffers and prioritize matches with same fileformat setting (don’t know if possible)
- [ ] Don’t include the same suggestions as the `cm_bufkeyword` source (maybe ncm handles this already?)
- [ ] Be more conservative about memory usage. The current implementation more or less holds a second copy of all the buffers content.
- [ ] Test it in real world scenarios.

Feel free to provide feedback.