### PR TITLE
Add Python docstring Optional Configuration Tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,19 @@ inoremap <expr> <Tab> pumvisible() ? "\<C-n>" : "\<Tab>"
 inoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"
 ```
 
+- Show and auto-close docstrings for Python completion
+
+```vim
+    " Add preview to see docstrings in the complete window.
+    let g:cm_completeopt = 'menu,menuone,noinsert,noselect,preview'
+
+    " Close the preview window automatically on InsertLeave
+    " https://github.com/davidhalter/jedi-vim/blob/eba90e615d73020365d43495fca349e5a2d4f995/ftplugin/python/jedi.vim#L44
+    augroup ncm_preview
+        autocmd! InsertLeave <buffer> if pumvisible() == 0|pclose|endif
+    augroup END
+```
+
 - If 'omnifunc' is the only available option, you may register it as a source
   for NCM.
  


### PR DESCRIPTION
I created an issue for this ( https://github.com/roxma/nvim-completion-manager/issues/132 ) and @LaBatata101 did as well (https://github.com/roxma/nvim-completion-manager/issues/162 ), so maybe other people can use it as well. Thanks for the awesome plugin!