### PR TITLE
Detect python2 in anaconda, for jedi source

### DIFF
--- a/pythonx/cm_sources/cm_jedi.py
+++ b/pythonx/cm_sources/cm_jedi.py
@@ -13,6 +13,10 @@ if 'VIRTUAL_ENV' in os.environ:
     py2 = os.path.join(os.environ['VIRTUAL_ENV'], 'bin', 'python2')
     if os.path.isfile(py2):
         py = 'python2'
+if 'CONDA_PREFIX' in os.environ:
+    py2 = os.path.join(os.environ['CONDA_PREFIX'], 'bin', 'python2')
+    if os.path.isfile(py2):
+        py = 'python2'
 
 from cm import register_source, getLogger, Base
 register_source(name='cm-jedi',


### PR DESCRIPTION
BTW, I think there should be a option for specifying python2/3, someone (like me) may have python3 installed but coding with python2.