### PR TITLE
Add setting for removing file extension from filepath completion.

### DIFF
--- a/doc/nvim-completion-manager.txt
+++ b/doc/nvim-completion-manager.txt
@@ -340,6 +340,11 @@ g:cm_completeopt
 			The value of 'completeopt' when NCM is active.
 			Default: "menu,menuone,noinsert,noselect"
 
+						*g:cm_filepath_strip_extension*
+g:cm_filepath_strip_extension
+			Strip file extension when completing filepaths.
+			Default: 0
+
 ==============================================================================
 5. API						*NCM-API*
 

--- a/plugin/cm.vim
+++ b/plugin/cm.vim
@@ -46,6 +46,8 @@ let g:cm_refresh_length = get(g:, 'cm_refresh_length', get(g:, 'cm_refresh_defau
 
 let g:cm_completeopt=get(g:,'cm_completeopt','menu,menuone,noinsert,noselect')
 
+let g:cm_filepath_strip_extension = get(g:,'cm_filepath_strip_extension', 0)
+
 au User CmSetup if exists('g:did_plugin_ultisnips') | call cm#sources#ultisnips#init() | endif
 au User CmSetup if exists('g:loaded_neosnippet') | call cm#sources#neosnippet#init() | endif
 au User CmSetup if exists('g:snipMateSources') | call cm#sources#snipmate#init() | endif

--- a/pythonx/cm_sources/cm_filepath.py
+++ b/pythonx/cm_sources/cm_filepath.py
@@ -27,6 +27,7 @@ class Source(Base):
 
     def __init__(self, nvim):
         super(Source, self).__init__(nvim)
+        self._strip_extension = self.nvim.vars['cm_filepath_strip_extension']
 
     def cm_refresh(self, info, ctx):
 
@@ -73,6 +74,11 @@ class Source(Base):
                     seen.add(p)
                     word = os.path.basename(p)
                     menu = '~' + label
+                    if self._strip_extension:
+                        [fname, ext] = os.path.splitext(word)
+                        word = fname
+                        if ext:
+                            menu += ' [' + ext[1:] + ']'
                     if expanded:
                         menu += '~ ' + p
                     matches.append(dict(word=word, icase=1, menu=menu, dup=1))


### PR DESCRIPTION
Some of the languages do not require extension to be present when importing files (in my case, javascript), and it is a bit annoying to autocomplete and delete extension manually each time. This setting solves that issue, but still shows what extension does file have.