### PR TITLE
icon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ completion in html style/script tag.
    [neosnippet.vim](https://github.com/Shougo/neosnippet.vim) or
    [vim-snipmate](https://github.com/garbas/vim-snipmate).
 6. [Nerdfont icon support](https://github.com/roxma/nvim-completion-manager/issues/185) (by MaiLunjiye),
-issues is welcome at this [fork](https://github.com/MaiLunJiye/nvim-completion-manager)
+issues is welcome at this [fork](https://github.com/MaiLunJiye/nvim-completion-manager).
+    Give me some recommendations about icon in [here](https://github.com/MaiLunJiye/nvim-completion-manager/issues/1)
 
 
 ## Scoping Sources:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ completion in html style/script tag.
    [Ultisnips](https://github.com/SirVer/ultisnips),
    [neosnippet.vim](https://github.com/Shougo/neosnippet.vim) or
    [vim-snipmate](https://github.com/garbas/vim-snipmate).
+6. [Nerdfont icon support](https://github.com/roxma/nvim-completion-manager/issues/185) (by MaiLunjiye),
+issues is welcome at this [fork](https://github.com/MaiLunJiye/nvim-completion-manager)
 
 
 ## Scoping Sources:

--- a/autoload/cm.vim
+++ b/autoload/cm.vim
@@ -326,7 +326,7 @@ func! cm#_core_complete(context, startcol, matches, not_changed, snippets)
 
     let s:context = a:context
     let s:startcol = a:startcol
-    let l:padcmd = 'extend(v:val,{"abbr":printf("%".strdisplaywidth(v:val["padding"])."s%s","",v:val["abbr"]),"kind":cm_icon#_iconSupport(get(v:val,"sourceName","NoName"),get(v:val,"kind",""))})'
+    let l:padcmd = 'extend(v:val,{"abbr":printf("%".strdisplaywidth(v:val["padding"])."s%s","",v:val["abbr"])})'
     let s:matches = map(a:matches, l:padcmd)
     let g:cm#snippet#snippets = a:snippets
 

--- a/autoload/cm.vim
+++ b/autoload/cm.vim
@@ -326,7 +326,7 @@ func! cm#_core_complete(context, startcol, matches, not_changed, snippets)
 
     let s:context = a:context
     let s:startcol = a:startcol
-    let l:padcmd = 'extend(v:val,{"abbr":printf("%".strdisplaywidth(v:val["padding"])."s%s","",v:val["abbr"])})'
+    let l:padcmd = 'extend(v:val,{"abbr":printf("%".strdisplaywidth(v:val["padding"])."s%s","",v:val["abbr"]),"kind":cm_icon#_iconSupport(get(v:val,"sourceName","NoName"),get(v:val,"kind",""))})'
     let s:matches = map(a:matches, l:padcmd)
     let g:cm#snippet#snippets = a:snippets
 

--- a/autoload/cm/sources/neosnippet.vim
+++ b/autoload/cm/sources/neosnippet.vim
@@ -10,7 +10,7 @@ endfunc
 
 function! cm#sources#neosnippet#cm_refresh(info, ctx)
 	let l:snips = values(neosnippet#helpers#get_completion_snippets())
-	let l:matches = map(l:snips, '{"word":v:val["word"], "dup":1, "icase":1, "menu": "Snip: " . v:val["menu_abbr"], "is_snippet": 1, "sourceName":"Snip", "kind":"Snip"}')
+	let l:matches = map(l:snips, '{"word":v:val["word"], "dup":1, "icase":1, "menu": "Snip: " . v:val["menu_abbr"], "is_snippet": 1,"kind":"Snip"}')
 	call cm#complete(a:info, a:ctx, a:ctx['startcol'], l:matches)
 endfunction
 

--- a/autoload/cm/sources/neosnippet.vim
+++ b/autoload/cm/sources/neosnippet.vim
@@ -10,7 +10,7 @@ endfunc
 
 function! cm#sources#neosnippet#cm_refresh(info, ctx)
 	let l:snips = values(neosnippet#helpers#get_completion_snippets())
-	let l:matches = map(l:snips, '{"word":v:val["word"], "dup":1, "icase":1, "menu": "Snip: " . v:val["menu_abbr"], "is_snippet": 1}')
+	let l:matches = map(l:snips, '{"word":v:val["word"], "dup":1, "icase":1, "menu": "Snip: " . v:val["menu_abbr"], "is_snippet": 1, "sourceName":"Snip", "kind":"Snip"}')
 	call cm#complete(a:info, a:ctx, a:ctx['startcol'], l:matches)
 endfunction
 

--- a/autoload/cm/sources/snipmate.vim
+++ b/autoload/cm/sources/snipmate.vim
@@ -10,7 +10,7 @@ endfunction
 
 function! cm#sources#snipmate#cm_refresh(info, ctx)
 	let l:word    = snipMate#WordBelowCursor()
-	let l:matches = map(snipMate#GetSnippetsForWordBelowCursorForComplete(''),'extend(v:val,{"dup":1, "is_snippet":1})')
+	let l:matches = map(snipMate#GetSnippetsForWordBelowCursorForComplete(''),'extend(v:val,{"dup":1, "is_snippet":1, "sourceName":"Snip", "kind":"Snip"})')
 	call cm#complete(a:info, a:ctx, a:ctx['col']-len(l:word), l:matches)
 endfunction
 

--- a/autoload/cm/sources/snipmate.vim
+++ b/autoload/cm/sources/snipmate.vim
@@ -10,7 +10,7 @@ endfunction
 
 function! cm#sources#snipmate#cm_refresh(info, ctx)
 	let l:word    = snipMate#WordBelowCursor()
-	let l:matches = map(snipMate#GetSnippetsForWordBelowCursorForComplete(''),'extend(v:val,{"dup":1, "is_snippet":1, "sourceName":"Snip", "kind":"Snip"})')
+	let l:matches = map(snipMate#GetSnippetsForWordBelowCursorForComplete(''),'extend(v:val,{"dup":1, "is_snippet":1,"kind":"Snip"})')
 	call cm#complete(a:info, a:ctx, a:ctx['col']-len(l:word), l:matches)
 endfunction
 

--- a/autoload/cm/sources/ultisnips.vim
+++ b/autoload/cm/sources/ultisnips.vim
@@ -12,7 +12,7 @@ func! cm#sources#ultisnips#cm_refresh(opt, ctx)
 
 	let l:snips = UltiSnips#SnippetsInCurrentScope()
 
-	let l:matches = map(keys(l:snips),'{"word":v:val, "dup":1, "icase":1, "info": l:snips[v:val], "is_snippet": 1}')
+	let l:matches = map(keys(l:snips),'{"word":v:val, "dup":1, "icase":1, "info": l:snips[v:val], "is_snippet": 1, "sourceName":"Snip", "kind":"Snip"}')
 
 	call cm#complete(a:opt, a:ctx, a:ctx['startcol'], l:matches)
 

--- a/autoload/cm/sources/ultisnips.vim
+++ b/autoload/cm/sources/ultisnips.vim
@@ -12,7 +12,7 @@ func! cm#sources#ultisnips#cm_refresh(opt, ctx)
 
 	let l:snips = UltiSnips#SnippetsInCurrentScope()
 
-	let l:matches = map(keys(l:snips),'{"word":v:val, "dup":1, "icase":1, "info": l:snips[v:val], "is_snippet": 1, "sourceName":"Snip", "kind":"Snip"}')
+	let l:matches = map(keys(l:snips),'{"word":v:val, "dup":1, "icase":1, "info": l:snips[v:val], "is_snippet": 1,"kind":"Snip"}')
 
 	call cm#complete(a:opt, a:ctx, a:ctx['startcol'], l:matches)
 

--- a/autoload/cm_icon.vim
+++ b/autoload/cm_icon.vim
@@ -1,0 +1,20 @@
+"=============================================================================
+" cm_devicon.vim   devicom support for ncm
+" Copyright (c) 2018 MaiLunjiye 
+" Author: MaiLunjiye <mailunjiye@gmail.com>
+" License: MIT
+"=============================================================================
+
+func! cm_icon#_iconSupport(sourceName,orgKind)
+    if g:cm_icon_kind_model == 0
+        return ""
+    endif
+
+    if g:cm_icon_kind_model == 1
+        return orgKind
+    endif
+
+    let l:sourceDict = get(g:cm_icon_kind_dict,a:sourceName, "NoName")
+    return get(l:sourceDict,a:orgKind,a:orgKind)
+endfunc
+

--- a/autoload/cm_icon.vim
+++ b/autoload/cm_icon.vim
@@ -1,5 +1,5 @@
 "=============================================================================
-" cm_devicon.vim   devicom support for ncm
+" cm_icon.vim   devicom support for ncm
 " Copyright (c) 2018 MaiLunjiye 
 " Author: MaiLunjiye <mailunjiye@gmail.com>
 " License: MIT

--- a/doc/nvim-completion-manager_icon.txt
+++ b/doc/nvim-completion-manager_icon.txt
@@ -1,0 +1,88 @@
+*nvim-completion-manager_icon.txt*    nerd font support for ncm
+
+                    nerdfont make ncm more beautiful
+
+Author: mailunjiye <mailunjiye@gmail.com>
+License: MIT
+
+nvim-completion-manager_icon		    *nvim-completion-manager_icon* *NCM-icon*
+
+1. Introduction					|NCM_icon-introduction|
+2. Settings					|NCM_icon-settings|
+3. API						|NCM_icon-API|
+
+==============================================================================
+1. Introduction					*NCM_icon-introduction*
+
+Nerdfont makes completion menu more beautiful
+
+==============================================================================
+2. Settings					*NCM_icon-settings*
+
+						*g:cm_icon_kind_model*
+g:cm_icon_kind_model
+			The module of the behavior.
+			0: no any words about complete kind
+			1: display complete kind in ascii
+			2: display complete kind in Nerdfont
+			   if the kind no in *g:cm_icon_kind_dict*,
+			   it will display like model 1
+
+			Default: 0
+
+						*g:cm_icon_kind_dict*
+g:cm_icon_kind_dict
+			A Dict maintain the complete kind and nerdfont.
+			You can change the icon what you like.
+
+			Struct:
+				{
+				'SourceName1': {
+					kindname1: nerdfont,
+					kindname2: nerdfont,
+				       }
+				'SourceName2': {
+					kindname1: nerdfont,
+					kindname2: nerdfont,
+				       }
+				}
+			Buildin like that:
+			let g:cm_icon_kind_dict = {
+				    \   "NoName":{
+				    \           },
+				    \   "cm_filepath":{
+				    \           "path":"",
+				    \           },
+				    \   "Snip":{
+				    \           "Snip":"",
+				    \           },
+				    \   "jedi":{
+				    \           "module":"",
+				    \           "function":"",
+				    \           "statement":"",
+				    \           "class":"",
+				    \           "instance":"",
+				    \           },
+				    \ }
+
+==============================================================================
+3. API						*NCM_icon-API*
+
+It is easy to make your sources support this feature.
+At First, you must know how to write a ncm source.
+you can refere *NCM-source_example*
+
+You change that lines can support this feature:
+
+    def cm_refresh(self,info,ctx):
+	# add key : SourceName and kind
+        matches = [dict(word=':'+k+':', menu=chr(v), SourceName='Emoj',
+			kind='emoj') for k,v in CODES]
+        self.complete(info, ctx, ctx['startcol'], matches)
+
+And Then add the nerdfont in *g:cm_icon_kind_dict*
+
+let g:cm_icon_kind_dict['Emoj'] = { "emjo":"" }
+
+==============================================================================
+vim: tw=78:ts=8:softtabstop=8:sw=8:ft=help:norl:noexpandtab:fen:noet:

--- a/doc/nvim-completion-manager_icon.txt
+++ b/doc/nvim-completion-manager_icon.txt
@@ -68,21 +68,26 @@ g:cm_icon_kind_dict
 ==============================================================================
 3. API						*NCM_icon-API*
 
-It is easy to make your sources support this feature.
-At First, you must know how to write a ncm source.
-you can refere *NCM-source_example*
-
-You change that lines can support this feature:
+Add a key named "kind" to the match dict.
+eg:
 
     def cm_refresh(self,info,ctx):
-	# add key : SourceName and kind
-        matches = [dict(word=':'+k+':', menu=chr(v), SourceName='Emoj',
-			kind='emoj') for k,v in CODES]
+        matches = [dict(word=':'+k+':', menu=chr(v), 
+			kind='emoj') for k,v in emoji.codes.CODES]
         self.complete(info, ctx, ctx['startcol'], matches)
 
-And Then add the nerdfont in *g:cm_icon_kind_dict*
+And Then add the nerdfont in *g:cm_icon_kind_dict* like that:
 
+let g:cm_icon_kind_dict['YourSourceName'] = {
+					\ "kind1" : "nerdfont1",
+					\ "kind2" : "nerdfont2",
+					\ }
+
+eg:
 let g:cm_icon_kind_dict['Emoj'] = { "emjo":"" }
+
+Why "kind" ?
+:help *complete-items*
 
 ==============================================================================
 vim: tw=78:ts=8:softtabstop=8:sw=8:ft=help:norl:noexpandtab:fen:noet:

--- a/plugin/cm_icon.vim
+++ b/plugin/cm_icon.vim
@@ -1,5 +1,5 @@
 "=============================================================================
-" cm_devIcon.vim   devicom support for ncm
+" cm_icon.vim   devicom support for ncm
 " Copyright (c) 2018 MaiLunjiye 
 " Author: MaiLunjiye <mailunjiye@gmail.com>
 " License: MIT
@@ -7,7 +7,7 @@
 
 let g:cm_icon_kind_model = 2
 
-" devicon support
+" icon support
 " {
 "   sourceName:{
 "       "kindname1":"nerdfont",

--- a/plugin/cm_icon.vim
+++ b/plugin/cm_icon.vim
@@ -32,7 +32,7 @@ let g:cm_icon_kind_dict = {
             \   "Go":{
             \           "fun":"",
             \           },
-            \   "jedi":{
+            \   "cm-jedi":{
             \           "module":"",
             \           "function":"",
             \           "statement":"",

--- a/plugin/cm_icon.vim
+++ b/plugin/cm_icon.vim
@@ -29,6 +29,9 @@ let g:cm_icon_kind_dict = {
             \   "tmux":{
             \           "tmux":"",
             \           },
+            \   "cm-tags":{
+            \           "Tag":"tag",
+            \           },
             \   "Go":{
             \           "fun":"",
             \           },

--- a/plugin/cm_icon.vim
+++ b/plugin/cm_icon.vim
@@ -1,0 +1,42 @@
+"=============================================================================
+" cm_devIcon.vim   devicom support for ncm
+" Copyright (c) 2018 MaiLunjiye 
+" Author: MaiLunjiye <mailunjiye@gmail.com>
+" License: MIT
+"=============================================================================
+
+let g:cm_icon_kind_model = 2
+
+" devicon support
+" {
+"   sourceName:{
+"       "kindname1":"nerdfont",
+"       "kindname2":"nerdfont",
+"   }
+" }
+let g:cm_icon_kind_dict = {
+            \   "NoName":{
+            \           },
+            \   "cm_filepath":{
+            \           "path":"",
+            \           },
+            \   "Snip":{
+            \           "Snip":"",
+            \           },
+            \   "keyword":{
+            \           "kw":"",
+            \           },
+            \   "tmux":{
+            \           "tmux":"",
+            \           },
+            \   "Go":{
+            \           "fun":"",
+            \           },
+            \   "jedi":{
+            \           "module":"",
+            \           "function":"",
+            \           "statement":"",
+            \           "class":"",
+            \           "instance":"",
+            \           },
+            \ }

--- a/pythonx/cm_core.py
+++ b/pythonx/cm_core.py
@@ -600,7 +600,8 @@ class CoreHandler(cm.Base):
         # fix some text
         for e in result:
             # support nerdfont icon
-            e['kind'] = self.nvim.call('cm_icon#_iconSupport',name,e['kind'])
+            if 'kind' in e:
+                e['kind'] = self.nvim.call('cm_icon#_iconSupport',name,e['kind'])
 
             if 'menu' not in e:
                 if 'info' in e and e['info'] and len(e['info'])<50:

--- a/pythonx/cm_core.py
+++ b/pythonx/cm_core.py
@@ -599,6 +599,8 @@ class CoreHandler(cm.Base):
 
         # fix some text
         for e in result:
+            # support nerdfont icon
+            e['kind'] = self.nvim.call('cm_icon#_iconSupport',name,e['kind'])
 
             if 'menu' not in e:
                 if 'info' in e and e['info'] and len(e['info'])<50:
@@ -613,7 +615,6 @@ class CoreHandler(cm.Base):
             else:
                 # e['menu'] = "<%s> %s"  % (self._sources[name]['abbreviation'], e['info'])
                 pass
-
         return result
 
 

--- a/pythonx/cm_sources/cm_bufkeyword.py
+++ b/pythonx/cm_sources/cm_bufkeyword.py
@@ -74,7 +74,7 @@ class Source(Base):
         # incremental refresh
         self.refresh_keyword(ctx,False)
 
-        matches = (dict(word=word,icase=1)  for word in self._words)
+        matches = (dict(word=word,icase=1, sourceName="keyword", kind="kw")  for word in self._words)
         matches = self.matcher.process(info, ctx, ctx['startcol'], matches)
 
         self.complete(info, ctx, ctx['startcol'], matches)

--- a/pythonx/cm_sources/cm_bufkeyword.py
+++ b/pythonx/cm_sources/cm_bufkeyword.py
@@ -74,7 +74,7 @@ class Source(Base):
         # incremental refresh
         self.refresh_keyword(ctx,False)
 
-        matches = (dict(word=word,icase=1, sourceName="keyword", kind="kw")  for word in self._words)
+        matches = (dict(word=word,icase=1,kind="kw")  for word in self._words)
         matches = self.matcher.process(info, ctx, ctx['startcol'], matches)
 
         self.complete(info, ctx, ctx['startcol'], matches)

--- a/pythonx/cm_sources/cm_filepath.py
+++ b/pythonx/cm_sources/cm_filepath.py
@@ -75,7 +75,8 @@ class Source(Base):
                     menu = '~' + label
                     if expanded:
                         menu += '~ ' + p
-                    matches.append(dict(word=word, icase=1, menu=menu, dup=1))
+                    # TODO : support  ryanoasis/vim-devicons in matches.menu
+                    matches.append(dict(word=word, icase=1, menu=menu, dup=1, kind='path', sourceName='cm_filepath'))
             except Exception as ex:
                 self.logger.info('exception on listing joined_dir [%s], %s', joined_dir, ex)
                 continue

--- a/pythonx/cm_sources/cm_filepath.py
+++ b/pythonx/cm_sources/cm_filepath.py
@@ -76,7 +76,7 @@ class Source(Base):
                     if expanded:
                         menu += '~ ' + p
                     # TODO : support  ryanoasis/vim-devicons in matches.menu
-                    matches.append(dict(word=word, icase=1, menu=menu, dup=1, kind='path', sourceName='cm_filepath'))
+                    matches.append(dict(word=word, icase=1, menu=menu, dup=1, kind='path'))
             except Exception as ex:
                 self.logger.info('exception on listing joined_dir [%s], %s', joined_dir, ex)
                 continue

--- a/pythonx/cm_sources/cm_gocode.py
+++ b/pythonx/cm_sources/cm_gocode.py
@@ -100,7 +100,6 @@ class Source(Base):
                         icase=1,
                         dup=1,
                         menu=complete.get('type',''),
-                        sourceName = "Go",
                         kind = complete.get('class',''),
                         # info=complete.get('doc',''),
                         )

--- a/pythonx/cm_sources/cm_gocode.py
+++ b/pythonx/cm_sources/cm_gocode.py
@@ -100,6 +100,8 @@ class Source(Base):
                         icase=1,
                         dup=1,
                         menu=complete.get('type',''),
+                        sourceName = "Go",
+                        kind = complete.get('class',''),
                         # info=complete.get('doc',''),
                         )
 

--- a/pythonx/cm_sources/cm_jedi.py
+++ b/pythonx/cm_sources/cm_jedi.py
@@ -87,7 +87,7 @@ class Source(Base):
 
         if re.search(r'^\s*(?!from|import).*?[(,]\s*$', typed):
             if signature_text:
-                matches = [dict(word='',empty=1,abbr=signature_text,dup=1),]
+                matches = [dict(word='',empty=1,abbr=signature_text,dup=1,sourceName="jedi",kind="module"),]
                 # refresh=True
                 # call signature popup doesn't need to be cached by the framework
                 self.complete(info, ctx, ctx['col'], matches, True)
@@ -106,7 +106,9 @@ class Source(Base):
                         icase=1,
                         dup=1,
                         menu=complete.description,
-                        info=complete.docstring()
+                        info=complete.docstring(),
+                        sourceName='jedi',
+                        kind=complete.type
                         )
 
             # Fix the user typed case

--- a/pythonx/cm_sources/cm_jedi.py
+++ b/pythonx/cm_sources/cm_jedi.py
@@ -87,7 +87,7 @@ class Source(Base):
 
         if re.search(r'^\s*(?!from|import).*?[(,]\s*$', typed):
             if signature_text:
-                matches = [dict(word='',empty=1,abbr=signature_text,dup=1,sourceName="jedi",kind="module"),]
+                matches = [dict(word='',empty=1,abbr=signature_text,dup=1,kind="module"),]
                 # refresh=True
                 # call signature popup doesn't need to be cached by the framework
                 self.complete(info, ctx, ctx['col'], matches, True)
@@ -107,7 +107,6 @@ class Source(Base):
                         dup=1,
                         menu=complete.description,
                         info=complete.docstring(),
-                        sourceName='jedi',
                         kind=complete.type
                         )
 

--- a/pythonx/cm_sources/cm_keyword_continue.py
+++ b/pythonx/cm_sources/cm_keyword_continue.py
@@ -169,6 +169,10 @@ class Source(Base):
                 hint += ' ...'
             e['menu'] = e['word'] + hint
             e['word'] = e['_rest_of_line']
+            
+            # devicon support
+            e['sourceName'] = "keyword"
+            e['kind'] = "kw"
             matches.insert(1,e)
 
         # if not matches:

--- a/pythonx/cm_sources/cm_keyword_continue.py
+++ b/pythonx/cm_sources/cm_keyword_continue.py
@@ -170,7 +170,7 @@ class Source(Base):
             e['menu'] = e['word'] + hint
             e['word'] = e['_rest_of_line']
             
-            # devicon support
+            # icon support
             e['kind'] = "kw"
             matches.insert(1,e)
 

--- a/pythonx/cm_sources/cm_keyword_continue.py
+++ b/pythonx/cm_sources/cm_keyword_continue.py
@@ -171,7 +171,6 @@ class Source(Base):
             e['word'] = e['_rest_of_line']
             
             # devicon support
-            e['sourceName'] = "keyword"
             e['kind'] = "kw"
             matches.insert(1,e)
 

--- a/pythonx/cm_sources/cm_tags.py
+++ b/pythonx/cm_sources/cm_tags.py
@@ -37,7 +37,7 @@ class Source(Base):
                     fields = line.split("\t")
                     if len(fields)<2:
                         continue
-                    tags[fields[0]] = dict(word=fields[0],menu='Tag: '+fields[1])
+                    tags[fields[0]] = dict(word=fields[0],menu=fields[1],kind='Tag')
             except Exception as ex:
                 logger.exception('binary_search_lines_by_prefix exception: %s', ex)
 

--- a/pythonx/cm_sources/cm_tmux.py
+++ b/pythonx/cm_sources/cm_tmux.py
@@ -86,7 +86,7 @@ class Source(Base):
 
         startcol = ctx['startcol']
 
-        matches = (dict(word=word,icase=1, sourceName="tmux",kind="tmux")  for word in self._words)
+        matches = (dict(word=word,icase=1,kind="tmux")  for word in self._words)
         matches = self.matcher.process(info, ctx, startcol, matches)
 
         self.complete(info, ctx, ctx['startcol'], matches)

--- a/pythonx/cm_sources/cm_tmux.py
+++ b/pythonx/cm_sources/cm_tmux.py
@@ -86,7 +86,7 @@ class Source(Base):
 
         startcol = ctx['startcol']
 
-        matches = (dict(word=word,icase=1)  for word in self._words)
+        matches = (dict(word=word,icase=1, sourceName="tmux",kind="tmux")  for word in self._words)
         matches = self.matcher.process(info, ctx, startcol, matches)
 
         self.complete(info, ctx, ctx['startcol'], matches)


### PR DESCRIPTION
fix issue [#185](https://github.com/roxma/nvim-completion-manager/issues/185)

使用了补全菜单的 kind 项来表示 补全类型(并使用nerdfont替换图标).
 但是您原来设计的部分源是把补全类型添加到 menu项, 所以暂时还存在信息冗余问题

同时,部分自带源的图标还没有设置, 等我找到漂亮的图标后会补上,或者[给点建议](https://github.com/MaiLunJiye/nvim-completion-manager/issues/1)

下一步计划是帮助其他源逐步支持这个特性