### PR TITLE
Enable CSS completion for Stylus, SASS and LESS

### DIFF
--- a/autoload/cm/sources/css.vim
+++ b/autoload/cm/sources/css.vim
@@ -1,9 +1,9 @@
 
 func! cm#sources#css#init()
     call cm#register_source({'name' : 'cm-css',
-                \ 'priority': 9, 
+                \ 'priority': 9,
                 \ 'scoping': 1,
-                \ 'scopes': ['css','scss'],
+                \ 'scopes': ['css','scss', 'stylus', 'less', 'sass'],
                 \ 'abbreviation': 'css',
                 \ 'word_pattern': '[\w\-]+',
                 \ 'cm_refresh_patterns':['[\w\-]+\s*:\s+'],


### PR DESCRIPTION
Just changed the scopes to enable for this filetypes also.