### PR TITLE
Use v:completed_item.user_data to pass extra data

### DIFF
--- a/autoload/cm.vim
+++ b/autoload/cm.vim
@@ -303,7 +303,7 @@ func! cm#_channel_cleanup(info)
 
 endfunc
 
-func! cm#_core_complete(context, startcol, matches, not_changed, snippets)
+func! cm#_core_complete(context, startcol, matches, not_changed)
 
     if s:should_skip()
         return
@@ -328,7 +328,6 @@ func! cm#_core_complete(context, startcol, matches, not_changed, snippets)
     let s:startcol = a:startcol
     let l:padcmd = 'extend(v:val,{"abbr":printf("%".strdisplaywidth(v:val["padding"])."s%s","",v:val["abbr"])})'
     let s:matches = map(a:matches, l:padcmd)
-    let g:cm#snippet#snippets = a:snippets
 
     call feedkeys(g:cm_completekeys, 'i')
 

--- a/pythonx/cm_core.py
+++ b/pythonx/cm_core.py
@@ -664,7 +664,12 @@ class CoreHandler(cm.Base):
                     else:
                         m['menu'] = '[ ] ' + m['menu']
 
-        self.nvim.call('cm#_core_complete', ctx, startcol, matches, not_changed, snippets)
+                    user_data = {}
+                    for key in {'snippet', 'snippet_word', 'is_snippet'}.intersection(m.keys()):
+                        user_data[key] = m[key]
+                    m['user_data'] = json.dumps(user_data)
+
+        self.nvim.call('cm#_core_complete', ctx, startcol, matches, not_changed)
         self._last_matches = matches
         self._last_startcol = startcol
 


### PR DESCRIPTION
Recent Vim versions mark 'v:completed_item' as read-only, hence it's
impossible to update this variable within a vimscript. Fortunately, an
alternative solution has been introduced - from now on
'v:completed_item' contains 'user_data' key that may contain various
user defined payload.

This patch get rids of some hacks, and make this plugin compatible with
recent versions of Vim, NeoVim and neosnippet.

Fixes #196
Fixes #199