### PR TITLE
Document abbrev_matcher dependency on ag binary

### DIFF
--- a/doc/nvim-completion-manager.txt
+++ b/doc/nvim-completion-manager.txt
@@ -243,6 +243,8 @@ g:cm_matcher.module
 				matcher.
 			`"cm_matchers.abbrev_matcher"`
 				A more intuitive version of fuzzy matching.
+				This module requires the ag binary from 
+				the_silver_searcher
 
 			Note: If you use non-prefix matcher, and haven't set
 			the |g:cm_completekeys| option, NCM will use


### PR DESCRIPTION
Added a note describing the dependency on ag for the abbrev_matrcher. Hopefully this helps anyone else that runs into issues from not having ag installed (#157)

Thank you for your work on this plugin!